### PR TITLE
feat: support running in non-default namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,8 +90,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	namespace, ok := os.LookupEnv("POD_NAMESPACE")
+	if !ok {
+		namespace = "kube-startup-cpu-boost-system"
+	}
+
 	certsReady := make(chan struct{})
-	if err = util.ManageCerts(mgr, "kube-startup-cpu-boost-system", certsReady); err != nil {
+	if err = util.ManageCerts(mgr, namespace, certsReady); err != nil {
 		setupLog.Error(err, "Unable to set up certificates")
 		os.Exit(1)
 	}

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -13,3 +13,8 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --zap-log-level=5
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace


### PR DESCRIPTION
I initially tried to run the operator in another namespace than `kube-startup-cpu-boost-system`, but this failed because the namespace is hardcoded when supplied to the cert-rotator.

This PR suggests to use the [downwardAPI](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to inject the current namespace as an environment variable to the workload. I have kept the hardcoded namespace name as a default for now.