### PR TITLE
ci: adding release-please automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,19 @@ on:
       - 'demo-app/**'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Commit Lint
+        uses: wagoid/commitlint-github-action@v5
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,34 @@
 name: release
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
+    steps:
+      - id: release-please
+        uses: google-github-actions/release-please-action@v4
+        with:
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
   goreleaser:
     runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ enabled.**
 
 To install the latest release of Kube Startup CPU Boost in your cluster, run the following command:
 
+ <!-- x-release-please-start-version -->
 ```sh
 kubectl apply -f https://github.com/google/kube-startup-cpu-boost/releases/download/v0.3.0/manifests.yaml
 ```
+ <!-- x-release-please-end -->
 
 The Kube Startup CPU Boost components run in `kube-startup-cpu-boost-system` namespace.
 


### PR DESCRIPTION
* Added commit linter to enforce [conventional commit format](https://github.com/conventional-changelog/commitlint/#what-is-commitlint)
* Introduced release automation with a [release-please](https://github.com/googleapis/release-please).