### PR TITLE
fix: POD webhook cfg blocks scheduling on failure

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-v1-pod
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: cpuboost.autoscaling.x-k8s.io
   rules:
   - apiGroups:
@@ -23,6 +23,7 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+  timeoutSeconds: 2
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/internal/webhook/podcpuboost_webhook.go
+++ b/internal/webhook/podcpuboost_webhook.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=cpuboost.autoscaling.x-k8s.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=ignore,sideEffects=None,timeoutSeconds=2,groups="",resources=pods,verbs=create,versions=v1,name=cpuboost.autoscaling.x-k8s.io,admissionReviewVersions=v1
 
 type podCPUBoostHandler struct {
 	decoder *admission.Decoder


### PR DESCRIPTION
Closes #27 