### PR TITLE
feat: option to disable (def) HTTP2 for servers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,13 @@ func main() {
 	metrics.Register()
 
 	tlsOpts := []func(*tls.Config){}
+	if !cfg.HTTP2 {
+		setupLog.Info("Disabling HTTP/2")
+		tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
+			cfg.NextProtos = append(cfg.NextProtos, "http/1.1")
+		})
+	}
+
 	webhookServer := webhook.NewServer(webhook.Options{
 		TLSOpts: tlsOpts,
 		Port:    9443,

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -15,6 +15,7 @@ spec:
   ports:
     - port: 443
       protocol: TCP
+      appProtocol: https
       targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 	SecureMetricsDefault        = false
 	ZapLogLevelDefault          = 0 // zapcore.InfoLevel
 	ZapDevelopmentDefault       = false
+	HTTP2Default                = false
 )
 
 // ConfigProvider provides the Kube Startup CPU Boost configuration
@@ -51,6 +52,8 @@ type Config struct {
 	ZapLogLevel int
 	// ZapDevelopment determines if the ZAP logger is in development mode
 	ZapDevelopment bool
+	// HTTP2 determines if the HTTP/2 protocol is used for webhook and metrics servers
+	HTTP2 bool
 }
 
 // LoadDefaults loads the default configuration values
@@ -63,4 +66,5 @@ func (c *Config) LoadDefaults() {
 	c.SecureMetrics = SecureMetricsDefault
 	c.ZapLogLevel = ZapLogLevelDefault
 	c.ZapDevelopment = ZapDevelopmentDefault
+	c.HTTP2 = HTTP2Default
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,5 +53,8 @@ var _ = Describe("Config", func() {
 		It("has valid ZAP development ", func() {
 			Expect(cfg.ZapDevelopment).To(Equal(config.ZapDevelopmentDefault))
 		})
+		It("has valid HTTP2 ", func() {
+			Expect(cfg.HTTP2).To(Equal(config.HTTP2Default))
+		})
 	})
 })

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -29,6 +29,7 @@ const (
 	SecureMetricsEnvVar        = "SECURE_METRICS"
 	ZapLogLevelEnvVar          = "ZAP_LOG_LEVEL"
 	ZapDevelopmentEnvVar       = "ZAP_DEVELOPMENT"
+	HTTP2EnvVar                = "HTTP2"
 )
 
 type LookupEnvFunc func(key string) (string, bool)
@@ -47,61 +48,102 @@ func (p *EnvConfigProvider) LoadConfig() (*Config, error) {
 	var errs []error
 	var config Config
 	config.LoadDefaults()
-
-	if v, ok := p.lookupFunc(PodNamespaceEnvVar); ok {
-		config.Namespace = v
-	}
-	if v, ok := p.lookupFunc(MgrCheckIntervalSecEnvVar); ok {
-		intVal, err := strconv.Atoi(v)
-		config.MgrCheckIntervalSec = intVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not an int: %s", MgrCheckIntervalSecEnvVar, err))
-		}
-	}
-	if v, ok := p.lookupFunc(LeaderElectionEnvVar); ok {
-		boolVal, err := strconv.ParseBool(v)
-		config.LeaderElection = boolVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not a bool: %s", LeaderElectionEnvVar, err))
-		}
-	}
-	if v, ok := p.lookupFunc(MetricsProbeBindAddrEnvVar); ok {
-		config.MetricsProbeBindAddr = v
-	}
-	if v, ok := p.lookupFunc(HealthProbeBindAddrEnvVar); ok {
-		config.HealthProbeBindAddr = v
-	}
-	if v, ok := p.lookupFunc(SecureMetricsEnvVar); ok {
-		boolVal, err := strconv.ParseBool(v)
-		config.SecureMetrics = boolVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not a bool: %s", SecureMetricsEnvVar, err))
-		}
-	}
-	if v, ok := p.lookupFunc(MgrCheckIntervalSecEnvVar); ok {
-		intVal, err := strconv.Atoi(v)
-		config.MgrCheckIntervalSec = intVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not an int: %s", MgrCheckIntervalSecEnvVar, err))
-		}
-	}
-	if v, ok := p.lookupFunc(ZapLogLevelEnvVar); ok {
-		intVal, err := strconv.Atoi(v)
-		config.ZapLogLevel = intVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not an int: %s", ZapLogLevelEnvVar, err))
-		}
-	}
-	if v, ok := p.lookupFunc(ZapDevelopmentEnvVar); ok {
-		boolVal, err := strconv.ParseBool(v)
-		config.ZapDevelopment = boolVal
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s value is not a bool: %s", ZapDevelopmentEnvVar, err))
-		}
-	}
+	p.loadPodNamespace(&config)
+	errs = p.loadMgrCheckIntervalSec(&config, errs)
+	errs = p.loadLeaderElection(&config, errs)
+	p.loadMetricsProbeBindAddr(&config)
+	p.loadHealthProbeBindAddr(&config)
+	errs = p.loadSecureMetrics(&config, errs)
+	errs = p.loadZapLogLevel(&config, errs)
+	errs = p.loadZapDevelopment(&config, errs)
+	errs = p.loadHTTP2(&config, errs)
 	var err error
 	if len(errs) > 0 {
 		err = errors.Join(errs...)
 	}
 	return &config, err
+}
+
+func (p *EnvConfigProvider) loadPodNamespace(config *Config) {
+	if v, ok := p.lookupFunc(PodNamespaceEnvVar); ok {
+		config.Namespace = v
+	}
+}
+
+func (p *EnvConfigProvider) loadMgrCheckIntervalSec(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(MgrCheckIntervalSecEnvVar); ok {
+		intVal, err := strconv.Atoi(v)
+		config.MgrCheckIntervalSec = intVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not an int: %s", MgrCheckIntervalSecEnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadLeaderElection(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(LeaderElectionEnvVar); ok {
+		boolVal, err := strconv.ParseBool(v)
+		config.LeaderElection = boolVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", LeaderElectionEnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadMetricsProbeBindAddr(config *Config) {
+	if v, ok := p.lookupFunc(MetricsProbeBindAddrEnvVar); ok {
+		config.MetricsProbeBindAddr = v
+	}
+}
+
+func (p *EnvConfigProvider) loadHealthProbeBindAddr(config *Config) {
+	if v, ok := p.lookupFunc(HealthProbeBindAddrEnvVar); ok {
+		config.HealthProbeBindAddr = v
+	}
+}
+
+func (p *EnvConfigProvider) loadSecureMetrics(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(SecureMetricsEnvVar); ok {
+		boolVal, err := strconv.ParseBool(v)
+		config.SecureMetrics = boolVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", SecureMetricsEnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadZapLogLevel(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(ZapLogLevelEnvVar); ok {
+		intVal, err := strconv.Atoi(v)
+		config.ZapLogLevel = intVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not an int: %s", ZapLogLevelEnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadZapDevelopment(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(ZapDevelopmentEnvVar); ok {
+		boolVal, err := strconv.ParseBool(v)
+		config.ZapDevelopment = boolVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", ZapDevelopmentEnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadHTTP2(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(HTTP2EnvVar); ok {
+		boolVal, err := strconv.ParseBool(v)
+		config.HTTP2 = boolVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", LeaderElectionEnvVar, err))
+		}
+	}
+	return
 }

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -123,5 +123,13 @@ var _ = Describe("EnvProvider", func() {
 				Expect(cfg.ZapDevelopment).To(BeTrue())
 			})
 		})
+		When("http2 variable is set", func() {
+			BeforeEach(func() {
+				lookupFuncMap[config.HTTP2EnvVar] = "true"
+			})
+			It("has valid http2", func() {
+				Expect(cfg.HTTP2).To(BeTrue())
+			})
+		})
 	})
 })


### PR DESCRIPTION
The HTTP2 for webhook and secure metrics servers will be disabled by default due to the HTTP/2 Stream Cancellation and
Rapid Reset CVEs:
- https://github.com/advisories/GHSA-qppj-fm5r-hxr3
- https://github.com/advisories/GHSA-4374-p667-p6c8

HTTP2 can be enabled by setting `HTTP2=true` env variable.