### PR TITLE
feat: cpu resource limits removed during boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Note: this is not an officially supported Google product.
   * [[Boost resources] fixed target](#boost-resources-fixed-target)
   * [[Boost duration] fixed time](#boost-duration-fixed-time)
   * [[Boost duration] POD condition](#boost-duration-pod-condition)
+* [Configuration](#configuration)
 * [License](#license)
 
 ## Description
@@ -35,7 +36,9 @@ The Kube Startup CPU Boost leverages [In-place Resource Resize for Kubernetes Po
 feature introduced in Kubernetes 1.27. It allows to revert workload's CPU resource requests and limits
 back to their original values without the need to recreate the Pods.
 
-The increase of resources is achieved by Mutating Admission Webhook.
+The increase of resources is achieved by Mutating Admission Webhook. By default, the webhook also
+removes CPU resource limits if present. The original resource values are set by operator after given
+period of time or when the POD condition is met.
 
 ## Installation
 
@@ -202,6 +205,23 @@ Define the POD condition, the resource boost effect will last until the conditio
        type: Ready
        status: "True" 
   ```
+
+## Configuration
+
+Kube Startup CPU Boost operator can be configured with environmental variables.
+
+| Variable | Type | Default | Description |
+| --- | --- | --- | --- |
+| `POD_NAMESPACE` | `string` | `kube-startup-cpu-boost-system` |  Kube Startup CPU Boost operator namespace |
+| `MGR_CHECK_INTERVAL` | `int` | `5` | Duration in seconds between boost manager checks for time based boost duration policy |
+| `LEADER_ELECTION` | `bool` | `false` | Enables leader election for controller manager |
+| `METRICS_PROBE_BIND_ADDR` | `string` | `:8080` | Address the metrics endpoint binds to |
+| `HEALTH_PROBE_BIND_ADDR` | `string` | `:8081` | Address the health probe endpoint binds to |
+| `SECURE_METRICS` | `bool` | `false` | Determines if the metrics endpoint is served securely |
+| `ZAP_LOG_LEVEL` | `int` | `0` | Log level for ZAP logger |
+| `ZAP_DEVELOPMENT` | `bool` | `false` | Enables development mode for ZAP logger |
+| `HTTP2` | `bool` | `false` | Determines if the HTTP/2 protocol is used for webhook and metrics servers|
+| `REMOVE_LIMITS` | `bool` | `true` | Enables operator to remove container CPU limits during the boost time |
 
 ## License
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ const (
 	ZapLogLevelDefault          = 0 // zapcore.InfoLevel
 	ZapDevelopmentDefault       = false
 	HTTP2Default                = false
+	RemoveLimitsDefault         = true
 )
 
 // ConfigProvider provides the Kube Startup CPU Boost configuration
@@ -42,9 +43,9 @@ type Config struct {
 	// LeaderElection enables leader election for controller manager
 	// Enabling this will ensure there is only one active controller manager
 	LeaderElection bool
-	// MetricsProbeBindAddr is the address the metric endpoint binds to
+	// MetricsProbeBindAddr is the address the metrics endpoint binds to
 	MetricsProbeBindAddr string
-	// HeathProbeBindAddr is the address the probe endpoint binds to
+	// HeathProbeBindAddr is the address the health probe endpoint binds to
 	HealthProbeBindAddr string
 	// SecureMetrics determines if the metrics endpoint is served securely
 	SecureMetrics bool
@@ -54,6 +55,8 @@ type Config struct {
 	ZapDevelopment bool
 	// HTTP2 determines if the HTTP/2 protocol is used for webhook and metrics servers
 	HTTP2 bool
+	// RemoveLimits determines if CPU resource limits should be removed during boost
+	RemoveLimits bool
 }
 
 // LoadDefaults loads the default configuration values
@@ -67,4 +70,5 @@ func (c *Config) LoadDefaults() {
 	c.ZapLogLevel = ZapLogLevelDefault
 	c.ZapDevelopment = ZapDevelopmentDefault
 	c.HTTP2 = HTTP2Default
+	c.RemoveLimits = RemoveLimitsDefault
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,11 +50,14 @@ var _ = Describe("Config", func() {
 		It("has valid ZAP log level", func() {
 			Expect(cfg.ZapLogLevel).To(Equal(config.ZapLogLevelDefault))
 		})
-		It("has valid ZAP development ", func() {
+		It("has valid ZAP development", func() {
 			Expect(cfg.ZapDevelopment).To(Equal(config.ZapDevelopmentDefault))
 		})
-		It("has valid HTTP2 ", func() {
+		It("has valid HTTP2", func() {
 			Expect(cfg.HTTP2).To(Equal(config.HTTP2Default))
+		})
+		It("has valid RemoveLimits", func() {
+			Expect(cfg.RemoveLimits).To(Equal(config.RemoveLimitsDefault))
 		})
 	})
 })

--- a/internal/config/env_provider.go
+++ b/internal/config/env_provider.go
@@ -30,6 +30,7 @@ const (
 	ZapLogLevelEnvVar          = "ZAP_LOG_LEVEL"
 	ZapDevelopmentEnvVar       = "ZAP_DEVELOPMENT"
 	HTTP2EnvVar                = "HTTP2"
+	RemoveLimitsEnvVar         = "REMOVE_LIMITS"
 )
 
 type LookupEnvFunc func(key string) (string, bool)
@@ -57,6 +58,7 @@ func (p *EnvConfigProvider) LoadConfig() (*Config, error) {
 	errs = p.loadZapLogLevel(&config, errs)
 	errs = p.loadZapDevelopment(&config, errs)
 	errs = p.loadHTTP2(&config, errs)
+	errs = p.loadRemoveLimits(&config, errs)
 	var err error
 	if len(errs) > 0 {
 		err = errors.Join(errs...)
@@ -142,7 +144,18 @@ func (p *EnvConfigProvider) loadHTTP2(config *Config, curErrs []error) (errs []e
 		boolVal, err := strconv.ParseBool(v)
 		config.HTTP2 = boolVal
 		if err != nil {
-			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", LeaderElectionEnvVar, err))
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", HTTP2EnvVar, err))
+		}
+	}
+	return
+}
+
+func (p *EnvConfigProvider) loadRemoveLimits(config *Config, curErrs []error) (errs []error) {
+	if v, ok := p.lookupFunc(RemoveLimitsEnvVar); ok {
+		boolVal, err := strconv.ParseBool(v)
+		config.RemoveLimits = boolVal
+		if err != nil {
+			errs = append(curErrs, fmt.Errorf("%s value is not a bool: %s", RemoveLimitsEnvVar, err))
 		}
 	}
 	return

--- a/internal/config/env_provider_test.go
+++ b/internal/config/env_provider_test.go
@@ -131,5 +131,13 @@ var _ = Describe("EnvProvider", func() {
 				Expect(cfg.HTTP2).To(BeTrue())
 			})
 		})
+		When("removeLimits variable is set", func() {
+			BeforeEach(func() {
+				lookupFuncMap[config.RemoveLimitsEnvVar] = "false"
+			})
+			It("has valid remove limits", func() {
+				Expect(cfg.RemoveLimits).To(BeFalse())
+			})
+		})
 	})
 })


### PR DESCRIPTION
closes #57
The CPU limits are removed by the webhook by default for the boost time period.