### PR TITLE
Add resourcePolicy to Boost Part within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ container(s) will be increase by the given percentage value.
 
 ```yaml
 spec:
-  containerPolicies:
-   - containerName: spring-rest-jpa
-     percentageIncrease:
-       value: 50
+  resourcePolicy:
+    containerPolicies:
+    - containerName: spring-rest-jpa
+      percentageIncrease:
+        value: 50
 ```
 
 ### [Boost resources] fixed target
@@ -176,11 +177,12 @@ higher than the ones in the container.
 
 ```yaml
 spec:
-  containerPolicies:
-   - containerName: spring-rest-jpa
-     fixedResources:
-       requests: "1"
-       limits: "2"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: spring-rest-jpa
+      fixedResources:
+        requests: "1"
+        limits: "2"
 ```
 
 ### [Boost duration] fixed time


### PR DESCRIPTION
Dear all,
While doing a PoC with K8s-Startup-Boost (which I really like by the way), I recognized that 'resourcePolicy' is missing within the Boost Part of README. Therefore, I adjusted the documentation slightly. 
Cheers,
Chris