### PR TITLE
feat: spec updates handled and reflected by boost manager

### DIFF
--- a/internal/controller/boost_controller.go
+++ b/internal/controller/boost_controller.go
@@ -150,6 +150,10 @@ func (r *StartupCPUBoostReconciler) Update(e event.UpdateEvent) bool {
 	}
 	log := r.Log.WithValues("name", boostObj.Name, "namespace", boostObj.Namespace)
 	log.V(5).Info("handling boost update event")
+	ctx := ctrl.LoggerInto(context.Background(), log)
+	if err := r.Manager.UpdateStartupCPUBoost(ctx, boostObj); err != nil {
+		log.Error(err, "boost update error")
+	}
 	return true
 }
 

--- a/internal/controller/boost_controller_test.go
+++ b/internal/controller/boost_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var _ = Describe("BoostController", func() {
@@ -139,6 +140,31 @@ var _ = Describe("BoostController", func() {
 					Expect(result).To(Equal(ctrl.Result{}))
 				})
 			})
+		})
+	})
+	Describe("receives update event", func() {
+		var (
+			updateEvent event.UpdateEvent
+			mgrMockCall *gomock.Call
+		)
+		BeforeEach(func() {
+			updateEvent = event.UpdateEvent{
+				ObjectNew: &autoscaling.StartupCPUBoost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "boost-001",
+						Namespace: "demo",
+					},
+				},
+			}
+			mgrMockCall = mockManager.EXPECT().UpdateStartupCPUBoost(
+				gomock.Any(), gomock.Eq(updateEvent.ObjectNew))
+		})
+		JustBeforeEach(func() {
+			ok := boostCtrl.Update(updateEvent)
+			Expect(ok).To(BeTrue())
+		})
+		It("calls manager with valid update", func() {
+			mgrMockCall.Times(1)
 		})
 	})
 })

--- a/internal/mock/boost_manager.go
+++ b/internal/mock/boost_manager.go
@@ -27,6 +27,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1alpha1 "github.com/google/kube-startup-cpu-boost/api/v1alpha1"
 	boost "github.com/google/kube-startup-cpu-boost/internal/boost"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ import (
 type MockManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerMockRecorder
+	isgomock struct{}
 }
 
 // MockManagerMockRecorder is the mock recorder for MockManager.
@@ -57,83 +59,97 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // AddStartupCPUBoost mocks base method.
-func (m *MockManager) AddStartupCPUBoost(arg0 context.Context, arg1 boost.StartupCPUBoost) error {
+func (m *MockManager) AddStartupCPUBoost(ctx context.Context, boost boost.StartupCPUBoost) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddStartupCPUBoost", arg0, arg1)
+	ret := m.ctrl.Call(m, "AddStartupCPUBoost", ctx, boost)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddStartupCPUBoost indicates an expected call of AddStartupCPUBoost.
-func (mr *MockManagerMockRecorder) AddStartupCPUBoost(arg0, arg1 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) AddStartupCPUBoost(ctx, boost any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStartupCPUBoost", reflect.TypeOf((*MockManager)(nil).AddStartupCPUBoost), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStartupCPUBoost", reflect.TypeOf((*MockManager)(nil).AddStartupCPUBoost), ctx, boost)
 }
 
 // RemoveStartupCPUBoost mocks base method.
-func (m *MockManager) RemoveStartupCPUBoost(arg0 context.Context, arg1, arg2 string) {
+func (m *MockManager) RemoveStartupCPUBoost(ctx context.Context, namespace, name string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RemoveStartupCPUBoost", arg0, arg1, arg2)
+	m.ctrl.Call(m, "RemoveStartupCPUBoost", ctx, namespace, name)
 }
 
 // RemoveStartupCPUBoost indicates an expected call of RemoveStartupCPUBoost.
-func (mr *MockManagerMockRecorder) RemoveStartupCPUBoost(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) RemoveStartupCPUBoost(ctx, namespace, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStartupCPUBoost", reflect.TypeOf((*MockManager)(nil).RemoveStartupCPUBoost), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStartupCPUBoost", reflect.TypeOf((*MockManager)(nil).RemoveStartupCPUBoost), ctx, namespace, name)
 }
 
 // SetStartupCPUBoostReconciler mocks base method.
-func (m *MockManager) SetStartupCPUBoostReconciler(arg0 reconcile.Reconciler) {
+func (m *MockManager) SetStartupCPUBoostReconciler(reconciler reconcile.TypedReconciler[reconcile.Request]) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetStartupCPUBoostReconciler", arg0)
+	m.ctrl.Call(m, "SetStartupCPUBoostReconciler", reconciler)
 }
 
 // SetStartupCPUBoostReconciler indicates an expected call of SetStartupCPUBoostReconciler.
-func (mr *MockManagerMockRecorder) SetStartupCPUBoostReconciler(arg0 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) SetStartupCPUBoostReconciler(reconciler any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStartupCPUBoostReconciler", reflect.TypeOf((*MockManager)(nil).SetStartupCPUBoostReconciler), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStartupCPUBoostReconciler", reflect.TypeOf((*MockManager)(nil).SetStartupCPUBoostReconciler), reconciler)
 }
 
 // Start mocks base method.
-func (m *MockManager) Start(arg0 context.Context) error {
+func (m *MockManager) Start(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0)
+	ret := m.ctrl.Call(m, "Start", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockManagerMockRecorder) Start(arg0 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Start(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), ctx)
 }
 
 // StartupCPUBoost mocks base method.
-func (m *MockManager) StartupCPUBoost(arg0, arg1 string) (boost.StartupCPUBoost, bool) {
+func (m *MockManager) StartupCPUBoost(namespace, name string) (boost.StartupCPUBoost, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartupCPUBoost", arg0, arg1)
+	ret := m.ctrl.Call(m, "StartupCPUBoost", namespace, name)
 	ret0, _ := ret[0].(boost.StartupCPUBoost)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StartupCPUBoost indicates an expected call of StartupCPUBoost.
-func (mr *MockManagerMockRecorder) StartupCPUBoost(arg0, arg1 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) StartupCPUBoost(namespace, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartupCPUBoost", reflect.TypeOf((*MockManager)(nil).StartupCPUBoost), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartupCPUBoost", reflect.TypeOf((*MockManager)(nil).StartupCPUBoost), namespace, name)
 }
 
 // StartupCPUBoostForPod mocks base method.
-func (m *MockManager) StartupCPUBoostForPod(arg0 context.Context, arg1 *v1.Pod) (boost.StartupCPUBoost, bool) {
+func (m *MockManager) StartupCPUBoostForPod(ctx context.Context, pod *v1.Pod) (boost.StartupCPUBoost, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartupCPUBoostForPod", arg0, arg1)
+	ret := m.ctrl.Call(m, "StartupCPUBoostForPod", ctx, pod)
 	ret0, _ := ret[0].(boost.StartupCPUBoost)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // StartupCPUBoostForPod indicates an expected call of StartupCPUBoostForPod.
-func (mr *MockManagerMockRecorder) StartupCPUBoostForPod(arg0, arg1 any) *gomock.Call {
+func (mr *MockManagerMockRecorder) StartupCPUBoostForPod(ctx, pod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartupCPUBoostForPod", reflect.TypeOf((*MockManager)(nil).StartupCPUBoostForPod), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartupCPUBoostForPod", reflect.TypeOf((*MockManager)(nil).StartupCPUBoostForPod), ctx, pod)
+}
+
+// UpdateStartupCPUBoost mocks base method.
+func (m *MockManager) UpdateStartupCPUBoost(ctx context.Context, spec *v1alpha1.StartupCPUBoost) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateStartupCPUBoost", ctx, spec)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateStartupCPUBoost indicates an expected call of UpdateStartupCPUBoost.
+func (mr *MockManagerMockRecorder) UpdateStartupCPUBoost(ctx, spec any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStartupCPUBoost", reflect.TypeOf((*MockManager)(nil).UpdateStartupCPUBoost), ctx, spec)
 }

--- a/internal/mock/startupcpuboost.go
+++ b/internal/mock/startupcpuboost.go
@@ -27,6 +27,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1alpha1 "github.com/google/kube-startup-cpu-boost/api/v1alpha1"
 	boost "github.com/google/kube-startup-cpu-boost/internal/boost"
 	duration "github.com/google/kube-startup-cpu-boost/internal/boost/duration"
 	resource "github.com/google/kube-startup-cpu-boost/internal/boost/resource"
@@ -38,6 +39,7 @@ import (
 type MockStartupCPUBoost struct {
 	ctrl     *gomock.Controller
 	recorder *MockStartupCPUBoostMockRecorder
+	isgomock struct{}
 }
 
 // MockStartupCPUBoostMockRecorder is the mock recorder for MockStartupCPUBoost.
@@ -58,17 +60,17 @@ func (m *MockStartupCPUBoost) EXPECT() *MockStartupCPUBoostMockRecorder {
 }
 
 // DeletePod mocks base method.
-func (m *MockStartupCPUBoost) DeletePod(arg0 context.Context, arg1 *v1.Pod) error {
+func (m *MockStartupCPUBoost) DeletePod(ctx context.Context, pod *v1.Pod) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePod", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeletePod", ctx, pod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeletePod indicates an expected call of DeletePod.
-func (mr *MockStartupCPUBoostMockRecorder) DeletePod(arg0, arg1 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) DeletePod(ctx, pod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockStartupCPUBoost)(nil).DeletePod), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockStartupCPUBoost)(nil).DeletePod), ctx, pod)
 }
 
 // DurationPolicies mocks base method.
@@ -86,17 +88,17 @@ func (mr *MockStartupCPUBoostMockRecorder) DurationPolicies() *gomock.Call {
 }
 
 // Matches mocks base method.
-func (m *MockStartupCPUBoost) Matches(arg0 *v1.Pod) bool {
+func (m *MockStartupCPUBoost) Matches(pod *v1.Pod) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Matches", arg0)
+	ret := m.ctrl.Call(m, "Matches", pod)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // Matches indicates an expected call of Matches.
-func (mr *MockStartupCPUBoostMockRecorder) Matches(arg0 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) Matches(pod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matches", reflect.TypeOf((*MockStartupCPUBoost)(nil).Matches), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matches", reflect.TypeOf((*MockStartupCPUBoost)(nil).Matches), pod)
 }
 
 // Name mocks base method.
@@ -128,47 +130,47 @@ func (mr *MockStartupCPUBoostMockRecorder) Namespace() *gomock.Call {
 }
 
 // Pod mocks base method.
-func (m *MockStartupCPUBoost) Pod(arg0 string) (*v1.Pod, bool) {
+func (m *MockStartupCPUBoost) Pod(name string) (*v1.Pod, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pod", arg0)
+	ret := m.ctrl.Call(m, "Pod", name)
 	ret0, _ := ret[0].(*v1.Pod)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // Pod indicates an expected call of Pod.
-func (mr *MockStartupCPUBoostMockRecorder) Pod(arg0 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) Pod(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pod", reflect.TypeOf((*MockStartupCPUBoost)(nil).Pod), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pod", reflect.TypeOf((*MockStartupCPUBoost)(nil).Pod), name)
 }
 
 // ResourcePolicy mocks base method.
-func (m *MockStartupCPUBoost) ResourcePolicy(arg0 string) (resource.ContainerPolicy, bool) {
+func (m *MockStartupCPUBoost) ResourcePolicy(containerName string) (resource.ContainerPolicy, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResourcePolicy", arg0)
+	ret := m.ctrl.Call(m, "ResourcePolicy", containerName)
 	ret0, _ := ret[0].(resource.ContainerPolicy)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // ResourcePolicy indicates an expected call of ResourcePolicy.
-func (mr *MockStartupCPUBoostMockRecorder) ResourcePolicy(arg0 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) ResourcePolicy(containerName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcePolicy", reflect.TypeOf((*MockStartupCPUBoost)(nil).ResourcePolicy), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourcePolicy", reflect.TypeOf((*MockStartupCPUBoost)(nil).ResourcePolicy), containerName)
 }
 
 // RevertResources mocks base method.
-func (m *MockStartupCPUBoost) RevertResources(arg0 context.Context, arg1 *v1.Pod) error {
+func (m *MockStartupCPUBoost) RevertResources(ctx context.Context, pod *v1.Pod) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevertResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "RevertResources", ctx, pod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RevertResources indicates an expected call of RevertResources.
-func (mr *MockStartupCPUBoostMockRecorder) RevertResources(arg0, arg1 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) RevertResources(ctx, pod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevertResources", reflect.TypeOf((*MockStartupCPUBoost)(nil).RevertResources), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevertResources", reflect.TypeOf((*MockStartupCPUBoost)(nil).RevertResources), ctx, pod)
 }
 
 // Stats mocks base method.
@@ -185,30 +187,44 @@ func (mr *MockStartupCPUBoostMockRecorder) Stats() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockStartupCPUBoost)(nil).Stats))
 }
 
-// UpsertPod mocks base method.
-func (m *MockStartupCPUBoost) UpsertPod(arg0 context.Context, arg1 *v1.Pod) error {
+// UpdateFromSpec mocks base method.
+func (m *MockStartupCPUBoost) UpdateFromSpec(ctx context.Context, boost *v1alpha1.StartupCPUBoost) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertPod", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateFromSpec", ctx, boost)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateFromSpec indicates an expected call of UpdateFromSpec.
+func (mr *MockStartupCPUBoostMockRecorder) UpdateFromSpec(ctx, boost any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFromSpec", reflect.TypeOf((*MockStartupCPUBoost)(nil).UpdateFromSpec), ctx, boost)
+}
+
+// UpsertPod mocks base method.
+func (m *MockStartupCPUBoost) UpsertPod(ctx context.Context, pod *v1.Pod) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertPod", ctx, pod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertPod indicates an expected call of UpsertPod.
-func (mr *MockStartupCPUBoostMockRecorder) UpsertPod(arg0, arg1 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) UpsertPod(ctx, pod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertPod", reflect.TypeOf((*MockStartupCPUBoost)(nil).UpsertPod), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertPod", reflect.TypeOf((*MockStartupCPUBoost)(nil).UpsertPod), ctx, pod)
 }
 
 // ValidatePolicy mocks base method.
-func (m *MockStartupCPUBoost) ValidatePolicy(arg0 context.Context, arg1 string) []*v1.Pod {
+func (m *MockStartupCPUBoost) ValidatePolicy(ctx context.Context, name string) []*v1.Pod {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatePolicy", arg0, arg1)
+	ret := m.ctrl.Call(m, "ValidatePolicy", ctx, name)
 	ret0, _ := ret[0].([]*v1.Pod)
 	return ret0
 }
 
 // ValidatePolicy indicates an expected call of ValidatePolicy.
-func (mr *MockStartupCPUBoostMockRecorder) ValidatePolicy(arg0, arg1 any) *gomock.Call {
+func (mr *MockStartupCPUBoostMockRecorder) ValidatePolicy(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePolicy", reflect.TypeOf((*MockStartupCPUBoost)(nil).ValidatePolicy), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePolicy", reflect.TypeOf((*MockStartupCPUBoost)(nil).ValidatePolicy), ctx, name)
 }


### PR DESCRIPTION
`StartupCPUBoost` object updates are now handled by the controller and reflected in the boost manager.
Fixes #6 #86 