### PR TITLE
fix: set the RuntimeDefault Seccomp profile for the container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,8 @@ spec:
           capabilities:
             drop:
               - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Set the Seccomp Profile for the container, allowing the workload to run in a namespace secured by [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) Restricted policy.