### PR TITLE
fix: resources are reverted on boosts updated with fixedDuration policy

### DIFF
--- a/internal/boost/manager.go
+++ b/internal/boost/manager.go
@@ -183,7 +183,11 @@ func (m *managerImpl) UpdateRegularCPUBoost(ctx context.Context,
 		log.V(5).Info("boost not found")
 		return nil
 	}
-	return boost.UpdateFromSpec(ctx, spec)
+	if err := boost.UpdateFromSpec(ctx, spec); err != nil {
+		return err
+	}
+	m.postProcessNewBoost(ctx, boost)
+	return nil
 }
 
 // GetRegularCPUBoost returns a regular startup cpu boost with a given name and namespace


### PR DESCRIPTION
fixes #116 
The resources were not reverted on boosts that were updated with fixedDuration policy after creation