### PR TITLE
feat: fixed duration policy uses POD scheduled time

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ spec:
 
 ### [Boost duration] fixed time
 
-Define the fixed amount of time, the resource boost effect will last for it since the POD's creation.
+Define the fixed amount of time, the resource boost effect will last for it since the
+**POD's schedule time**.
 
 ```yaml
 spec:

--- a/internal/boost/duration/fixed.go
+++ b/internal/boost/duration/fixed.go
@@ -52,5 +52,10 @@ func (p *FixedDurationPolicy) Duration() time.Duration {
 
 func (p *FixedDurationPolicy) Valid(pod *v1.Pod) bool {
 	now := p.timeFunc()
-	return pod.CreationTimestamp.Add(p.duration).After(now)
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodScheduled && condition.Status == v1.ConditionTrue {
+			return condition.LastTransitionTime.Add(p.duration).After(now)
+		}
+	}
+	return true
 }

--- a/internal/boost/manager_test.go
+++ b/internal/boost/manager_test.go
@@ -434,10 +434,15 @@ var _ = Describe("Manager", func() {
 				durationSeconds = 60
 
 				pod = podTemplate.DeepCopy()
-				creationTimestamp := time.Now().
+				scheduledTimestamp := time.Now().
 					Add(-1 * time.Duration(durationSeconds) * time.Second).
 					Add(-1 * time.Minute)
-				pod.CreationTimestamp = metav1.NewTime(creationTimestamp)
+				pod.Status.Conditions = []corev1.PodCondition{
+					{
+						LastTransitionTime: metav1.NewTime(scheduledTimestamp),
+						Type:               corev1.PodScheduled,
+						Status:             corev1.ConditionTrue,
+					}}
 				mockClient = mock.NewMockClient(mockCtrl)
 				mockReconciler = mock.NewMockReconciler(mockCtrl)
 


### PR DESCRIPTION
The Fixed duration policy uses POD scheduled time instead of POD creation time
fixes #119