### PR TITLE
fix: fail fast in case of server version retrieval failure

### DIFF
--- a/internal/controller/boost_controller.go
+++ b/internal/controller/boost_controller.go
@@ -104,7 +104,7 @@ func (r *StartupCPUBoostReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *StartupCPUBoostReconciler) SetupWithManager(mgr ctrl.Manager,
-	serverVersion *version.Info) error {
+	serverVersion string) error {
 	boostPodHandler := NewBoostPodHandler(r.Manager, ctrl.Log.WithName("pod-handler"))
 	lsPredicate, err := predicate.LabelSelectorPredicate(*boostPodHandler.GetPodLabelSelector())
 	if err != nil {
@@ -174,7 +174,7 @@ func (r *StartupCPUBoostReconciler) Generic(e event.GenericEvent) bool {
 
 // shouldUseLegacyRevertMode determines if legacy resource revert mode should be used
 // basing on server version
-func shouldUseLegacyRevertMode(serverVersion *version.Info) (legacyMode bool) {
+func shouldUseLegacyRevertMode(serverVersion string) (legacyMode bool) {
 	return version.CompareKubeAwareVersionStrings(WantedServerVersionForNewRevert,
-		serverVersion.GitVersion) < 0
+		serverVersion) < 0
 }

--- a/internal/controller/boost_controller_test.go
+++ b/internal/controller/boost_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/version"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
@@ -62,7 +61,7 @@ var _ = Describe("BoostController", func() {
 	Describe("Setups with manager", func() {
 		var (
 			mockCtrlManager *mock.MockCtrlManager
-			serverVersion   *version.Info
+			serverVersion   string
 			err             error
 		)
 		BeforeEach(func() {
@@ -83,9 +82,7 @@ var _ = Describe("BoostController", func() {
 		})
 		When("server version is newer or equal to 1.32.0", func() {
 			BeforeEach(func() {
-				serverVersion = &version.Info{
-					GitVersion: "v1.32.0",
-				}
+				serverVersion = "v1.32.0"
 			})
 			It("doesn't error", func() {
 				Expect(err).NotTo(HaveOccurred())
@@ -96,9 +93,7 @@ var _ = Describe("BoostController", func() {
 		})
 		When("server version is less than 1.32.0", func() {
 			BeforeEach(func() {
-				serverVersion = &version.Info{
-					GitVersion: "v1.29.2",
-				}
+				serverVersion = "v1.29.2"
 			})
 			It("doesn't error", func() {
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When an error occurs during server version retrieval, e.g., in case of a timeout, the controller will panic later during setup, because of the nil pointer dereference. Let's exit immediately to avoid it.