### PR TITLE
feat(chart): supporting nodeSelector and tolerations

### DIFF
--- a/charts/kube-startup-cpu-boost/templates/deployment.yaml
+++ b/charts/kube-startup-cpu-boost/templates/deployment.yaml
@@ -79,6 +79,14 @@ spec:
           readOnly: true
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
         8 }}
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: kube-startup-cpu-boost-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/kube-startup-cpu-boost/values.yaml
+++ b/charts/kube-startup-cpu-boost/values.yaml
@@ -19,9 +19,11 @@ controllerManager:
       requests:
         cpu: 10m
         memory: 64Mi
+  nodeSelector: {}
   podSecurityContext:
     runAsNonRoot: true
   replicas: 1
+  tolerations: []
   serviceAccount:
     annotations: {}
 kubernetesClusterDomain: cluster.local


### PR DESCRIPTION
This pull request adds support for customizing node scheduling for the `controllerManager` deployment in the `kube-startup-cpu-boost` Helm chart. Users can now specify `nodeSelector` and `tolerations` in the values file to control which nodes the controller pods are scheduled on and which taints they tolerate.

**Helm chart enhancements for pod scheduling:**

* Added support for `nodeSelector` and `tolerations` in the `controllerManager` section of `values.yaml`, allowing users to specify node selection and taint toleration preferences.
* Updated the `deployment.yaml` template to include the `nodeSelector` and `tolerations` fields when provided, enabling the new configuration options in the rendered deployment manifest.