### PR TITLE
feat(matcher): add custom matcher to handle regexp/glob/etc for startupcpuboost containerName

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Note: this is not an officially supported Google product.
   * [[Boost resources] fixed target](#boost-resources-fixed-target)
   * [[Boost duration] fixed time](#boost-duration-fixed-time)
   * [[Boost duration] POD condition](#boost-duration-pod-condition)
+  * [[Boost resources] pattern matching for containers](#boost-resources-pattern-matching-for-containers)
 * [Configuration](#configuration)
 * [Metrics](#metrics)
 * [License](#license)
@@ -200,6 +201,82 @@ Define the POD condition, the resource boost effect will last until the conditio
        type: Ready
        status: "True" 
   ```
+
+### [Boost resources] pattern matching for containers
+
+You can define `containerPolicies` that apply to one or more containers by using pattern matching on the container name. This allows for flexible and powerful policy definitions.
+
+The operator supports three types of patterns:
+
+#### **1. Exact Match**
+Matches a specific container name exactly. This pattern has the **highest precedence**.
+```yaml
+containerPolicies:
+- containerName: my-app-container
+  percentageIncrease:
+    value: 50
+```
+
+#### **2. Glob Patterns** 
+Use wildcard patterns familiar from shell commands. Glob patterns have a higher precedence than Regex patterns and the universal wildcard (`*`). More specific globs (e.g., `app-*-db`) are prioritized over less specific ones (e.g., `*-db`).
+
+Supported wildcards:
+- `*`: matches any sequence of characters.
+- `?`: matches any single character.
+- `[]`: matches any character within the brackets. Can be negated with `!`.
+```yaml
+containerPolicies:
+# Matches istio-sidecar, envoy-sidecar, etc.
+- containerName: '*-sidecar'
+  percentageIncrease:
+    value: 30
+# Matches app-v1, app-v2, etc.
+- containerName: 'app-v?'
+  percentageIncrease:
+    value: 25
+```
+
+#### **3. Regular Expressions**
+For complex patterns, use regular expressions. The pattern must start with `^` and/or end with `$`. Regex patterns have a lower precedence than Exact and Glob patterns but higher than the universal wildcard (`*`).
+```yaml
+containerPolicies:
+# Matches containers starting with app or api
+- containerName: '^(app|api).*$'
+  percentageIncrease:
+    value: 40
+```
+
+#### **Precedence and Evaluation**
+When multiple `containerPolicies` are defined, they are evaluated based on pattern specificity, not the order in the YAML file. The first policy that matches a container's name, based on the precedence order below, will be applied.
+
+The precedence order is:
+1.  **Exact Match** (e.g., `app-frontend`)
+2.  **Glob Pattern** (e.g., `*-db`, `app-*`)
+3.  **Regular Expression** (e.g., `^app-.*$`)
+4.  **Universal Wildcard** (`*`)
+
+**Example: Mixed Policies**
+
+Given the following policies, the `app-frontend` container will get the `200%` increase (exact match), `api-backend` will get the `150%` increase (regex match), `cache-db` will get the `100%` increase (glob match), and any other container will get the `50%` increase (wildcard).
+
+```yaml
+spec:
+  resourcePolicy:
+    containerPolicies:
+    # Order does not matter; policies are sorted by precedence.
+    - containerName: '*' # 4th (Wildcard)
+      percentageIncrease:
+        value: 50
+    - containerName: '^(api)-.*$' # 3rd (Regex)
+      percentageIncrease:
+        value: 150
+    - containerName: '*-db' # 2nd (Glob)
+      percentageIncrease:
+        value: 100
+    - containerName: 'app-frontend' # 1st (Exact)
+      percentageIncrease:
+        value: 200
+```
 
 ## Configuration
 

--- a/examples/pattern-matching-examples.yaml
+++ b/examples/pattern-matching-examples.yaml
@@ -1,0 +1,92 @@
+---
+# Examples demonstrating container name pattern matching.
+#
+# The operator applies container policies based on a specific precedence order,
+# not the order they appear in the YAML file.
+#
+# Precedence Order:
+# 1. Exact Match (e.g., "my-app")
+# 2. Glob Pattern (e.g., "*-sidecar")
+# 3. Regular Expression (e.g., "^(app|api).*$")
+# 4. Universal Wildcard ("*")
+#
+---
+apiVersion: autoscaling.x-k8s.io/v1alpha1
+kind: StartupCPUBoost
+metadata:
+  name: pattern-precedence-example
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: my-microservices-app
+  resourcePolicy:
+    containerPolicies:
+    # The order here is intentionally mixed to demonstrate that precedence,
+    # not file order, determines which policy is applied.
+
+    # 4. Universal Wildcard (lowest precedence)
+    # Matches any container not matched by a more specific pattern.
+    - containerName: '*'
+      percentageIncrease:
+        value: 25
+
+    # 3. Regular Expression
+    # Matches containers like 'auth-service', 'payment-service'.
+    - containerName: '^(auth|payment)-.*$'
+      percentageIncrease:
+        value: 200
+
+    # 2. Glob Pattern
+    # Matches containers like 'envoy-sidecar', 'istio-proxy-sidecar'.
+    - containerName: '*-sidecar'
+      percentageIncrease:
+        value: 75
+
+    # 1. Exact Match (highest precedence)
+    # Matches only the container named 'api-gateway'.
+    - containerName: 'api-gateway'
+      fixedResources:
+        requests: "2"
+        limits: "4"
+
+  durationPolicy:
+    podCondition:
+      type: Ready
+      status: "True"
+---
+apiVersion: autoscaling.x-k8s.io/v1alpha1
+kind: StartupCPUBoost
+metadata:
+  name: advanced-glob-example
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: web-services
+  resourcePolicy:
+    containerPolicies:
+    # A more specific glob takes precedence over a less specific one.
+    # 'web-app-v2' is more specific than 'web-*' because it's longer.
+    - containerName: 'web-app-v2'
+      percentageIncrease:
+        value: 150
+    - containerName: 'web-*'
+      percentageIncrease:
+        value: 100
+
+    # Question mark matches a single character. Matches 'db-1', 'db-2', etc.
+    - containerName: 'db-?'
+      fixedResources:
+        requests: "0.5"
+        limits: "1"
+
+    # Character class matches a range. Matches 'cache-0', 'cache-1', etc.
+    - containerName: 'cache-[0-9]'
+      fixedResources:
+        requests: "0.3"
+        limits: "0.8"
+  durationPolicy:
+    fixedDuration:
+      unit: Seconds
+      value: 90

--- a/examples/pattern-matching-examples.yaml
+++ b/examples/pattern-matching-examples.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 # Examples demonstrating container name pattern matching.
 #

--- a/internal/boost/pattern/matcher.go
+++ b/internal/boost/pattern/matcher.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pattern
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Matcher matches container names against patterns (glob, regex, or exact)
+type Matcher struct {
+	pattern string
+	regex   *regexp.Regexp
+	isRegex bool
+	isGlob  bool
+	isExact bool
+}
+
+// NewMatcher creates a new pattern matcher from a container name pattern
+func NewMatcher(pattern string) (*Matcher, error) {
+	m := &Matcher{
+		pattern: pattern,
+	}
+
+	// Check if pattern is a regex (starts with ^ and/or ends with $)
+	if strings.HasPrefix(pattern, "^") || strings.HasSuffix(pattern, "$") {
+		m.isRegex = true
+		regex, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
+		}
+		m.regex = regex
+		return m, nil
+	}
+
+	// Check if pattern contains glob wildcards
+	if strings.Contains(pattern, "*") || strings.Contains(pattern, "?") || strings.Contains(pattern, "[") {
+		m.isGlob = true
+		return m, nil
+	}
+
+	// Exact match
+	m.isExact = true
+	return m, nil
+}
+
+// Matches returns true if the container name matches the pattern
+func (m *Matcher) Matches(containerName string) bool {
+	if m.isRegex {
+		return m.regex.MatchString(containerName)
+	}
+
+	if m.isGlob {
+		return matchGlob(m.pattern, containerName)
+	}
+
+	// Exact match
+	return m.pattern == containerName
+}
+
+// matchGlob implements simple glob pattern matching
+// Supports: *, ?, [abc], [a-z], [!abc]
+func matchGlob(pattern, name string) bool {
+	return globMatch(pattern, name, 0, 0)
+}
+
+func globMatch(pattern, name string, pi, ni int) bool {
+	for pi < len(pattern) {
+		switch pattern[pi] {
+		case '*':
+			// Handle multiple consecutive asterisks
+			for pi < len(pattern) && pattern[pi] == '*' {
+				pi++
+			}
+
+			// If asterisk is at the end, it matches everything
+			if pi == len(pattern) {
+				return true
+			}
+
+			// Try to match the rest of the pattern with all suffixes of name
+			for ni <= len(name) {
+				if globMatch(pattern, name, pi, ni) {
+					return true
+				}
+				ni++
+			}
+			return false
+
+		case '?':
+			// ? matches any single character except empty
+			if ni >= len(name) {
+				return false
+			}
+			pi++
+			ni++
+
+		case '[':
+			// Character class [abc], [a-z], [!abc]
+			if ni >= len(name) {
+				return false
+			}
+
+			nextClose := strings.IndexByte(pattern[pi:], ']')
+			if nextClose == -1 {
+				return false // Invalid pattern: unclosed [
+			}
+
+			charClass := pattern[pi+1 : pi+nextClose]
+			negate := false
+			if len(charClass) > 0 && charClass[0] == '!' {
+				negate = true
+				charClass = charClass[1:]
+			}
+
+			matched := matchCharClass(charClass, name[ni])
+			if negate {
+				matched = !matched
+			}
+			if !matched {
+				return false
+			}
+
+			pi += nextClose + 1
+			ni++
+
+		case '\\':
+			// Escape next character
+			if pi+1 >= len(pattern) {
+				return false
+			}
+			pi++
+			if ni >= len(name) || pattern[pi] != name[ni] {
+				return false
+			}
+			pi++
+			ni++
+
+		default:
+			// Regular character must match exactly
+			if ni >= len(name) || pattern[pi] != name[ni] {
+				return false
+			}
+			pi++
+			ni++
+		}
+	}
+
+	return ni == len(name)
+}
+
+func matchCharClass(charClass string, char byte) bool {
+	i := 0
+	for i < len(charClass) {
+		// Check for range (e.g., a-z)
+		if i+2 < len(charClass) && charClass[i+1] == '-' {
+			if char >= charClass[i] && char <= charClass[i+2] {
+				return true
+			}
+			i += 3
+			continue
+		}
+
+		if char == charClass[i] {
+			return true
+		}
+		i++
+	}
+	return false
+}
+
+func (m *Matcher) IsExact() bool {
+	return m.isExact
+}
+
+func (m *Matcher) IsRegex() bool {
+	return m.isRegex
+}
+
+func (m *Matcher) IsGlob() bool {
+	return m.isGlob
+}
+
+func (m *Matcher) Pattern() string {
+	return m.pattern
+}

--- a/internal/boost/pattern/matcher_test.go
+++ b/internal/boost/pattern/matcher_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pattern
+
+import (
+	"testing"
+)
+
+func TestExactMatching(t *testing.T) {
+	tests := []struct {
+		name           string
+		pattern        string
+		containerNames []string
+		shouldMatch    []bool
+	}{
+		{
+			name:           "exact single match",
+			pattern:        "app",
+			containerNames: []string{"app", "application", "app-v1", "my-app"},
+			shouldMatch:    []bool{true, false, false, false},
+		},
+		{
+			name:           "exact with hyphens",
+			pattern:        "web-server",
+			containerNames: []string{"web-server", "web-server-v1", "web-serve", "web-servers"},
+			shouldMatch:    []bool{true, false, false, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(tt.pattern)
+			if err != nil {
+				t.Fatalf("NewMatcher failed: %v", err)
+			}
+
+			for i, containerName := range tt.containerNames {
+				got := m.Matches(containerName)
+				want := tt.shouldMatch[i]
+				if got != want {
+					t.Errorf("pattern %q container %q: got %v, want %v", tt.pattern, containerName, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGlobPatterns(t *testing.T) {
+	tests := []struct {
+		name           string
+		pattern        string
+		containerNames []string
+		shouldMatch    []bool
+	}{
+		{
+			name:           "wildcard prefix",
+			pattern:        "web-*",
+			containerNames: []string{"web-app", "web-server", "web", "myapp-web", "web-"},
+			shouldMatch:    []bool{true, true, false, false, true},
+		},
+		{
+			name:           "wildcard suffix",
+			pattern:        "*-sidecar",
+			containerNames: []string{"istio-sidecar", "envoy-sidecar", "sidecar", "my-sidecar-app", "sidecar-app"},
+			shouldMatch:    []bool{true, true, false, false, false},
+		},
+		{
+			name:           "wildcard both sides",
+			pattern:        "*app*",
+			containerNames: []string{"app", "myapp", "app-sidecar", "sidecar-app", "application", "myapplicationx"},
+			shouldMatch:    []bool{true, true, true, true, true, true},
+		},
+		{
+			name:           "multiple wildcards",
+			pattern:        "app-*-v*",
+			containerNames: []string{"app-main-v1", "app-db-v2", "app-v1", "app-cache-v1-test", "app-service"},
+			shouldMatch:    []bool{true, true, false, true, false},
+		},
+		{
+			name:           "question mark single char",
+			pattern:        "app-v?",
+			containerNames: []string{"app-v1", "app-v2", "app-va", "app-v", "app-v12"},
+			shouldMatch:    []bool{true, true, true, false, false},
+		},
+		{
+			name:           "character class",
+			pattern:        "app-v[0-9]",
+			containerNames: []string{"app-v0", "app-v5", "app-va", "app-v", "app-v10"},
+			shouldMatch:    []bool{true, true, false, false, false},
+		},
+		{
+			name:           "character class with negation",
+			pattern:        "app-v[!a-z]",
+			containerNames: []string{"app-v1", "app-va", "app-v-", "app-v"},
+			shouldMatch:    []bool{true, false, true, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(tt.pattern)
+			if err != nil {
+				t.Fatalf("NewMatcher failed: %v", err)
+			}
+
+			if !m.IsGlob() {
+				t.Errorf("Expected glob pattern for %q", tt.pattern)
+			}
+
+			for i, containerName := range tt.containerNames {
+				got := m.Matches(containerName)
+				want := tt.shouldMatch[i]
+				if got != want {
+					t.Errorf("pattern %q container %q: got %v, want %v", tt.pattern, containerName, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRegexPatterns(t *testing.T) {
+	tests := []struct {
+		name           string
+		pattern        string
+		containerNames []string
+		shouldMatch    []bool
+	}{
+		{
+			name:           "simple prefix regex",
+			pattern:        "^web-.*$",
+			containerNames: []string{"web-app", "web-server", "web", "myapp-web", "web-"},
+			shouldMatch:    []bool{true, true, false, false, true},
+		},
+		{
+			name:           "alternation regex",
+			pattern:        "^(app|api).*$",
+			containerNames: []string{"app", "api", "application", "api-server", "myapp", "my-api"},
+			shouldMatch:    []bool{true, true, true, true, false, false},
+		},
+		{
+			name:           "version pattern regex",
+			pattern:        "^.*-v[0-9]+$",
+			containerNames: []string{"app-v1", "service-v2", "v1", "app-v", "app-v1beta"},
+			shouldMatch:    []bool{true, true, false, false, false},
+		},
+		{
+			name:           "complex pattern",
+			pattern:        "^(app|svc)-[a-z]+-v\\d+$",
+			containerNames: []string{"app-db-v1", "svc-cache-v2", "app-v1", "app-db-1", "app-DB-v1"},
+			shouldMatch:    []bool{true, true, false, false, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(tt.pattern)
+			if err != nil {
+				t.Fatalf("NewMatcher failed: %v", err)
+			}
+
+			if !m.IsRegex() {
+				t.Errorf("Expected regex pattern for %q", tt.pattern)
+			}
+
+			for i, containerName := range tt.containerNames {
+				got := m.Matches(containerName)
+				want := tt.shouldMatch[i]
+				if got != want {
+					t.Errorf("pattern %q container %q: got %v, want %v", tt.pattern, containerName, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWildcardSpecial(t *testing.T) {
+	tests := []struct {
+		name           string
+		pattern        string
+		containerNames []string
+		shouldMatch    []bool
+	}{
+		{
+			name:           "single asterisk matches all",
+			pattern:        "*",
+			containerNames: []string{"app", "web-server", "", "service-v1", "x"},
+			shouldMatch:    []bool{true, true, true, true, true},
+		},
+		{
+			name:           "double asterisk",
+			pattern:        "**",
+			containerNames: []string{"app", "web-server", "", "any-thing"},
+			shouldMatch:    []bool{true, true, true, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(tt.pattern)
+			if err != nil {
+				t.Fatalf("NewMatcher failed: %v", err)
+			}
+
+			for i, containerName := range tt.containerNames {
+				got := m.Matches(containerName)
+				want := tt.shouldMatch[i]
+				if got != want {
+					t.Errorf("pattern %q container %q: got %v, want %v", tt.pattern, containerName, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestInvalidPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{
+			name:    "valid regex",
+			pattern: "^[a-z]+$",
+			wantErr: false,
+		},
+		{
+			name:    "invalid regex unclosed bracket",
+			pattern: "^[a-z$",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewMatcher(tt.pattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewMatcher(%q): got err %v, wantErr %v", tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMatcherTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		isExact bool
+		isGlob  bool
+		isRegex bool
+	}{
+		{
+			name:    "exact match",
+			pattern: "app",
+			isExact: true,
+			isGlob:  false,
+			isRegex: false,
+		},
+		{
+			name:    "glob pattern",
+			pattern: "app-*",
+			isExact: false,
+			isGlob:  true,
+			isRegex: false,
+		},
+		{
+			name:    "regex pattern",
+			pattern: "^app-.*$",
+			isExact: false,
+			isGlob:  false,
+			isRegex: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMatcher(tt.pattern)
+			if err != nil {
+				t.Fatalf("NewMatcher failed: %v", err)
+			}
+
+			if m.IsExact() != tt.isExact {
+				t.Errorf("IsExact: got %v, want %v", m.IsExact(), tt.isExact)
+			}
+			if m.IsGlob() != tt.isGlob {
+				t.Errorf("IsGlob: got %v, want %v", m.IsGlob(), tt.isGlob)
+			}
+			if m.IsRegex() != tt.isRegex {
+				t.Errorf("IsRegex: got %v, want %v", m.IsRegex(), tt.isRegex)
+			}
+		})
+	}
+}

--- a/internal/boost/startupcpuboost.go
+++ b/internal/boost/startupcpuboost.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	autoscaling "github.com/google/kube-startup-cpu-boost/api/v1alpha1"
 	"github.com/google/kube-startup-cpu-boost/internal/boost/duration"
+	"github.com/google/kube-startup-cpu-boost/internal/boost/pattern"
 	bpod "github.com/google/kube-startup-cpu-boost/internal/boost/pod"
 	"github.com/google/kube-startup-cpu-boost/internal/boost/resource"
 	"github.com/google/kube-startup-cpu-boost/internal/metrics"
@@ -88,18 +90,24 @@ type StartupCPUBoostStats struct {
 	TotalContainerBoosts int
 }
 
+// containerPolicyEntry holds a matcher and its associated policy
+type containerPolicyEntry struct {
+	matcher *pattern.Matcher
+	policy  resource.ContainerPolicy
+}
+
 // StartupCPUBoostImpl is an implementation of a StartupCPUBoost CRD
 type StartupCPUBoostImpl struct {
 	sync.RWMutex
-	name             string
-	namespace        string
-	selector         labels.Selector
-	durationPolicies map[string]duration.Policy
-	resourcePolicies map[string]resource.ContainerPolicy
-	pods             map[string]*corev1.Pod
-	client           client.Client
-	stats            StartupCPUBoostStats
-	legacyRevertMode bool
+	name              string
+	namespace         string
+	selector          labels.Selector
+	durationPolicies  map[string]duration.Policy
+	containerPolicies []containerPolicyEntry
+	pods              map[string]*corev1.Pod
+	client            client.Client
+	stats             StartupCPUBoostStats
+	legacyRevertMode  bool
 }
 
 // NewStartupCPUBoost constructs startup-cpu-boost implementation from a given API spec
@@ -112,16 +120,20 @@ func NewStartupCPUBoost(client client.Client, boost *autoscaling.StartupCPUBoost
 	if err != nil {
 		return nil, err
 	}
+	containerPolicies, err := buildContainerPolicies(resourcePolicies)
+	if err != nil {
+		return nil, err
+	}
 	return &StartupCPUBoostImpl{
-		name:             boost.Name,
-		namespace:        boost.Namespace,
-		selector:         selector,
-		durationPolicies: mapDurationPolicy(boost.Spec.DurationPolicy),
-		resourcePolicies: resourcePolicies,
-		pods:             make(map[string]*corev1.Pod),
-		client:           client,
-		stats:            StartupCPUBoostStats{},
-		legacyRevertMode: legacyRevertMode,
+		name:              boost.Name,
+		namespace:         boost.Namespace,
+		selector:          selector,
+		durationPolicies:  mapDurationPolicy(boost.Spec.DurationPolicy),
+		containerPolicies: containerPolicies,
+		pods:              make(map[string]*corev1.Pod),
+		client:            client,
+		stats:             StartupCPUBoostStats{},
+		legacyRevertMode:  legacyRevertMode,
 	}, nil
 }
 
@@ -136,9 +148,17 @@ func (b *StartupCPUBoostImpl) Namespace() string {
 }
 
 // ResourcePolicy returns the resource policy for a given container
+// It uses pattern matching with the following priority:
+// 1. Try all patterns in order (exact matches first, then glob, then regex)
+// 2. Return the first matching policy
+// 3. If multiple policies match, the first one defined in the spec is used
 func (b *StartupCPUBoostImpl) ResourcePolicy(containerName string) (resource.ContainerPolicy, bool) {
-	policy, ok := b.resourcePolicies[containerName]
-	return policy, ok
+	for _, entry := range b.containerPolicies {
+		if entry.matcher.Matches(containerName) {
+			return entry.policy, true
+		}
+	}
+	return nil, false
 }
 
 // DurationPolicies returns configured duration policies
@@ -245,8 +265,12 @@ func (b *StartupCPUBoostImpl) UpdateFromSpec(ctx context.Context, boost *autosca
 	if err != nil {
 		return err
 	}
+	containerPolicies, err := buildContainerPolicies(resourcePolicies)
+	if err != nil {
+		return err
+	}
 	b.selector = selector
-	b.resourcePolicies = resourcePolicies
+	b.containerPolicies = containerPolicies
 	b.durationPolicies = mapDurationPolicy(boost.Spec.DurationPolicy)
 	return nil
 }
@@ -378,6 +402,58 @@ func mapResourcePolicy(spec autoscaling.ResourcePolicy) (map[string]resource.Con
 		return nil, errors.Join(errs...)
 	}
 	return policies, nil
+}
+
+// buildContainerPolicies converts the resource policies to container policy entries with pattern matchers
+// It creates matchers for each container name pattern (exact, glob, or regex)
+func buildContainerPolicies(policies map[string]resource.ContainerPolicy) ([]containerPolicyEntry, error) {
+	var errs []error
+	var entries []containerPolicyEntry
+
+	for containerName, policy := range policies {
+		matcher, err := pattern.NewMatcher(containerName)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid pattern for container %s: %w", containerName, err))
+			continue
+		}
+		entries = append(entries, containerPolicyEntry{
+			matcher: matcher,
+			policy:  policy,
+		})
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	// Sort policies by specificity (exact > glob > regex > wildcard) to ensure correct precedence
+	sort.Slice(entries, func(i, j int) bool {
+		m1 := entries[i].matcher
+		m2 := entries[j].matcher
+
+		// Handle wildcard '*' as the lowest priority
+		isM1Wildcard := m1.Pattern() == "*"
+		isM2Wildcard := m2.Pattern() == "*"
+		if isM1Wildcard != isM2Wildcard {
+			return isM2Wildcard // m2 is wildcard, so m1 comes first.
+		}
+
+		if m1.IsExact() != m2.IsExact() {
+			return m1.IsExact() // Exact comes before glob/regex
+		}
+
+		// Between globs and regex, glob is more specific
+		if m1.IsGlob() != m2.IsGlob() {
+			return m1.IsGlob() // Glob comes before regex
+		}
+
+		// For patterns of same type, sort by length (desc) as a proxy for specificity,
+		// then alphabetically for stability.
+		if len(m1.Pattern()) != len(m2.Pattern()) {
+			return len(m1.Pattern()) > len(m2.Pattern())
+		}
+		return m1.Pattern() < m2.Pattern()
+	})
+	return entries, nil
 }
 
 // fixedPolicyToDuration maps the attributes from FixedDurationPolicy API spec to the

--- a/internal/boost/startupcpuboost_test.go
+++ b/internal/boost/startupcpuboost_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +103,172 @@ var _ = Describe("StartupCPUBoost", func() {
 				fixedPolicy, _ := p.(*resource.FixedPolicy)
 				Expect(fixedPolicy.Requests()).To(Equal(containerTwoFixedReq))
 				Expect(fixedPolicy.Limits()).To(Equal(containerTwoFixedLim))
+			})
+		})
+		When("the spec has wildcard container policy", func() {
+			var (
+				wildcardFixedReq = apiResource.MustParse("0.5")
+				wildcardFixedLim = apiResource.MustParse("1.5")
+			)
+			BeforeEach(func() {
+				spec.Spec.ResourcePolicy = autoscaling.ResourcePolicy{
+					ContainerPolicies: []autoscaling.ContainerPolicy{
+						{
+							ContainerName: "*",
+							FixedResources: &autoscaling.FixedResources{
+								Requests: wildcardFixedReq,
+								Limits:   wildcardFixedLim,
+							},
+						},
+					},
+				}
+			})
+			It("does not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns wildcard policy for any container name", func() {
+				// Test with a container name that has no specific entry
+				p, ok := boost.ResourcePolicy("any-container")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(wildcardFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(wildcardFixedLim))
+			})
+			It("returns wildcard policy for another container name", func() {
+				p, ok := boost.ResourcePolicy("another-container")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(wildcardFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(wildcardFixedLim))
+			})
+		})
+		When("the spec has both specific and wildcard container policies", func() {
+			var (
+				containerOneName            = "container-one"
+				containerOnePercValue int64 = 120
+				wildcardFixedReq            = apiResource.MustParse("0.5")
+				wildcardFixedLim            = apiResource.MustParse("1.5")
+			)
+			BeforeEach(func() {
+				spec.Spec.ResourcePolicy = autoscaling.ResourcePolicy{
+					ContainerPolicies: []autoscaling.ContainerPolicy{
+						{
+							ContainerName: containerOneName,
+							PercentageIncrease: &autoscaling.PercentageIncrease{
+								Value: containerOnePercValue,
+							},
+						},
+						{
+							ContainerName: "*",
+							FixedResources: &autoscaling.FixedResources{
+								Requests: wildcardFixedReq,
+								Limits:   wildcardFixedLim,
+							},
+						},
+					},
+				}
+			})
+			It("does not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns specific policy for exact container match", func() {
+				p, ok := boost.ResourcePolicy(containerOneName)
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.PercentageContainerPolicy{}))
+				percPolicy, _ := p.(*resource.PercentageContainerPolicy)
+				Expect(percPolicy.Percentage()).To(Equal(containerOnePercValue))
+			})
+			It("returns wildcard policy for non-matching container", func() {
+				p, ok := boost.ResourcePolicy("other-container")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(wildcardFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(wildcardFixedLim))
+			})
+		})
+		When("the spec has mixed exact, glob, and regex policies", func() {
+			var (
+				exactContainerName      = "app-frontend"
+				exactPercValue    int64 = 200
+				globPattern             = "*-db"
+				globFixedReq            = apiResource.MustParse("1.2")
+				globFixedLim            = apiResource.MustParse("2.2")
+				regexPattern            = "^app-.*$"
+				regexFixedReq           = apiResource.MustParse("0.8")
+				regexFixedLim           = apiResource.MustParse("1.8")
+				wildcardFixedReq        = apiResource.MustParse("0.1")
+				wildcardFixedLim        = apiResource.MustParse("0.2")
+			)
+			BeforeEach(func() {
+				spec.Spec.ResourcePolicy = autoscaling.ResourcePolicy{
+					ContainerPolicies: []autoscaling.ContainerPolicy{
+						// Order is intentionally mixed to test sorting
+						{
+							ContainerName: regexPattern, // Regex
+							FixedResources: &autoscaling.FixedResources{
+								Requests: regexFixedReq,
+								Limits:   regexFixedLim,
+							},
+						},
+						{
+							ContainerName: exactContainerName, // Exact
+							PercentageIncrease: &autoscaling.PercentageIncrease{
+								Value: exactPercValue,
+							},
+						},
+						{
+							ContainerName: "*", // Wildcard glob
+							FixedResources: &autoscaling.FixedResources{
+								Requests: wildcardFixedReq,
+								Limits:   wildcardFixedLim,
+							},
+						},
+						{
+							ContainerName: globPattern, // More specific glob
+							FixedResources: &autoscaling.FixedResources{
+								Requests: globFixedReq,
+								Limits:   globFixedLim,
+							},
+						},
+					},
+				}
+			})
+			It("does not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns exact policy for the exact match", func() {
+				p, ok := boost.ResourcePolicy(exactContainerName)
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.PercentageContainerPolicy{}))
+				percPolicy, _ := p.(*resource.PercentageContainerPolicy)
+				Expect(percPolicy.Percentage()).To(Equal(exactPercValue))
+			})
+			It("returns glob policy for the glob match", func() {
+				p, ok := boost.ResourcePolicy("postgres-db")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(globFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(globFixedLim))
+			})
+			It("returns regex policy for the regex match that is not an exact or glob match", func() {
+				p, ok := boost.ResourcePolicy("app-backend")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(regexFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(regexFixedLim))
+			})
+			It("returns wildcard policy for a non-matching container", func() {
+				p, ok := boost.ResourcePolicy("other-unmatched-container")
+				Expect(ok).To(BeTrue())
+				Expect(p).To(BeAssignableToTypeOf(&resource.FixedPolicy{}))
+				fixedPolicy, _ := p.(*resource.FixedPolicy)
+				Expect(fixedPolicy.Requests()).To(Equal(wildcardFixedReq))
+				Expect(fixedPolicy.Limits()).To(Equal(wildcardFixedLim))
 			})
 		})
 		When("the spec has container policy without resource policy", func() {


### PR DESCRIPTION
This pull request adds support for pattern matching in the `containerName` field of `StartupCPUBoost` resource policies, allowing policies to target multiple containers dynamically.

**Enhancements for container policy matching:**

- Added a custom `pattern.Matcher` to support exact strings, glob wildcards (e.g., `web-*`), and regular expressions (e.g., `^(app|api).*$`), enabling broader targeting of containers.

- Updated the core `StartupCPUBoostImpl` to evaluate container policies based on pattern specificity (Exact > Glob > Regex > Wildcard). The first matching policy according to this precedence order is applied.

- Included new examples and precedence order documentation in the `README.md` and added a `pattern-matching-examples.yaml` manifest to demonstrate the new configuration options.
<br />
This pull request solves #129  

p.s great tool :)