### PR TITLE
fix(controller): avoid nil dereference on invalid boost selector

### DIFF
--- a/internal/controller/boost_controller.go
+++ b/internal/controller/boost_controller.go
@@ -142,6 +142,7 @@ func (r *StartupCPUBoostReconciler) Create(e event.CreateEvent) bool {
 	cpuBoost, err := boost.NewStartupCPUBoost(boostObj, bostConfig)
 	if err != nil {
 		log.Error(err, "boost creation error")
+		return true
 	}
 	if err := r.Manager.AddRegularCPUBoost(ctx, cpuBoost); err != nil {
 		if !errors.Is(err, boost.ErrStartupCPUBoostAlreadyExists) {

--- a/internal/controller/boost_controller_test.go
+++ b/internal/controller/boost_controller_test.go
@@ -224,4 +224,40 @@ var _ = Describe("BoostController", func() {
 			mgrMockCall.Times(1)
 		})
 	})
+	Describe("receives create event", func() {
+		var (
+			createEvent event.CreateEvent
+			realManager boost.Manager
+		)
+		BeforeEach(func() {
+			realManager = boost.NewManager(mockClient)
+			boostCtrl.Manager = realManager
+		})
+		When("boost selector is invalid", func() {
+			BeforeEach(func() {
+				createEvent = event.CreateEvent{Object: &autoscaling.StartupCPUBoost{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "boost-001",
+						Namespace: "demo",
+					},
+					Selector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: "InvalidOperator",
+							},
+						},
+					},
+				}}
+			})
+			It("does not panic", func() {
+				Expect(func() { boostCtrl.Create(createEvent) }).NotTo(Panic())
+			})
+			It("does not register the boost", func() {
+				boostCtrl.Create(createEvent)
+				_, ok := realManager.GetRegularCPUBoost(context.TODO(), "boost-001", "demo")
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Problem

`StartupCPUBoostReconciler.Create` (used as the controller's event filter) calls `boost.NewStartupCPUBoost` and logs the error but then unconditionally calls `r.Manager.AddRegularCPUBoost(ctx, cpuBoost)`. When the boost selector is invalid, `NewStartupCPUBoost` returns `(nil, err)`, so `AddRegularCPUBoost` receives a nil `StartupCPUBoost` interface and dereferences it in `managerImpl.AddRegularCPUBoost` (`boost.Name()`), panicking and crashing the operator.

This is reachable because the selector is not validated anywhere on the write path:
- The CRD schema for `selector.matchExpressions[].operator` has no enum, and `matchLabels` / `matchExpressions[].key` / `values` have no label key/value regex validation.
- The validating webhook (`StartupCPUBoostWebhook.validate`) only checks container policies and the duration policy, never the selector.

So a `StartupCPUBoost` such as:
```yaml
selector:
  matchExpressions:
    - key: app
      operator: InvalidOperator
```
is accepted by the API server and crashes the leader operator in `managerImpl.AddRegularCPUBoost`.

## Fix

Return early from `Create` when `boost.NewStartupCPUBoost` fails, so the invalid object is never passed to the manager. The reconciler still runs for the object and reports the `Active=False` condition, matching the existing not-found status path.

## Verification

Added a regression test (`internal/controller/boost_controller_test.go`) that constructs a boost with an invalid selector and asserts `Create` does not panic and does not register the boost. Before the fix this test panics with `runtime error: invalid memory address or nil pointer dereference` at `managerImpl.AddRegularCPUBoost`; after the fix it passes. `go build ./...` and `go test ./...` are green.